### PR TITLE
[Remove] 퇴사자 상세 페이지 링크 삭제

### DIFF
--- a/profile/software/software.md
+++ b/profile/software/software.md
@@ -7,6 +7,6 @@
 ## 👥 Members
 
 - [🐷 이주성](/profile/software/members/jusung.md)
-- [🐶 권영민](/profile/software/members/youngmin.md)
+- ~~🐶 권영민~~
 - [🐯 박종우](/profile/software/members/jongwoo.md)
 - [🐷 윤군재](/profile/software/members/gunjae.md)


### PR DESCRIPTION
## 내용

> 마지막 PR 이 되겠군요. 근무하는 동안 함께 즐겁게 일할 수 있어서 좋았습니다. 떠난 이후에도 이 기분을 쉽게 잊긴 힘들거 같습니다.

해당 PR 의 내용은 다음과 같습니다.
- 퇴사자(권영민/software) 상세페이지 링크 삭제하고 dashed-line 으로 변경
  - 상세 페이지를 삭제하진 않음

## 추가

![Screenshot 2023-10-04 at 6 40 03 PM](https://github.com/PLAIF-dev/.github/assets/52237605/7e6a02b3-ac78-4a98-a68e-f50475ea15bd)
